### PR TITLE
Fixed some broken links on Software page, added PathWiz to the list

### DIFF
--- a/docs/learningsbgn.md
+++ b/docs/learningsbgn.md
@@ -7,7 +7,7 @@ permalink: /learningsbgn
 # Learning SBGN
 
 This page offers a brief introduction to the SBGN, and, in particular, to the Process Description language as the currently most used language of the SBGN standard. Redrawing a small example diagram will help with a quick start, and examples of the SBGN Bricks will help to align biological concepts with their graphical expressions.
-  
+
 ## The three languages of SBGN
 
 <p>There are three complementary languages in SBGN: Activity Flow (AF), Process Description (PD) and Entity Relationship (ER).</p>
@@ -31,8 +31,8 @@ This page offers a brief introduction to the SBGN, and, in particular, to the Pr
 <!--![example](/sbgn/images/learning/PD_catalysis_example.png){: .left-image width="200px"}-->
 <table style="font-size:100%;">
     <tr>
-      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/images/learning/glucose.png"/> <br /> 
-          <a href="/sbgn/images/learning/glucose.sbgn">SBGN-ML</a> &ensp; 
+      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/images/learning/glucose.png"/> <br />
+          <a href="/sbgn/images/learning/glucose.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/images/learning/glucose.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"> </td>
     </tr>
@@ -42,7 +42,7 @@ This page offers a brief introduction to the SBGN, and, in particular, to the Pr
 
 ## SBGN PD Bricks
 
-<p>The <a href="https://sbgnbricks.org/pd/">SBGN Bricks</a> project presents a tamplate-based approach that makes it simpler to learn and start applying the standard without necesserily being familiar with all the specifications. Here are some illustrations of how biological concepts such as metabolic reaction or complex formation can be reflected in the SBGN Process Description language (Junker et al., 2012, <a href="https://dx.doi.org/10.1016/j.tibtech.2012.08.003">doi:10.1016/j.tibtech.2012.08.003</a>).</p>
+<p>The <a href="https://sbgnbricks.org/pd/">SBGN Bricks</a> project presents a template-based approach that makes it simpler to learn and start applying the standard without necessarily being familiar with all the specifications. Here are some illustrations of how biological concepts such as metabolic reaction or complex formation can be reflected in the SBGN Process Description language (Junker et al., 2012, <a href="https://dx.doi.org/10.1016/j.tibtech.2012.08.003">doi:10.1016/j.tibtech.2012.08.003</a>).</p>
 
 The example bricks are developed using the <a href="https://immersive-analytics.infotech.monash.edu/vanted/addons/sbgn-ed/">SBGN-ED</a> add-on of <a href="https://www.cls.uni-konstanz.de/software/vanted/">VANTED</a> editor (desktop application). All the bricks are available for downloading in SBGN-ML format and can be opened online in <a href="http://newteditor.org/">Newt</a> (online editor). The <a href="https://github.com/wiese42/krayon4sbgn" target="_blank">Krayon</a> editor (desktop application) supports the SBGN Bricks and the available templates can be used to design a diagram by adding one brick after another. To download Krayon please use the <a href="https://github.com/wiese42/krayon4sbgn/releases" target="_blank">Releases</a> page.
 
@@ -50,20 +50,20 @@ The example bricks are developed using the <a href="https://immersive-analytics.
 
 <table style="font-size:100%;">
     <tr>
-    <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_catalysis_irr_1_1.png"/> <br /> 
-          <a href="/sbgn/downloads/bricks/PD_catalysis_irr_1_1.sbgn">SBGN-ML</a> &ensp; 
+    <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_catalysis_irr_1_1.png"/> <br />
+          <a href="/sbgn/downloads/bricks/PD_catalysis_irr_1_1.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/downloads/bricks/PD_catalysis_irr_1_1.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"><strong>Catalysis: irreversible reacton.</strong> The enzyme catalyses an irreversible metabolic process which consumes substrate S1 and produces product P1. The enzyme is a represented as a <i>macromolecule</i> connected to the <i>process</i> glyph by a <i>catalysis</i> arc. The substrate and the product of the biochemical reaction are represented by <i>simple chemical</i> glyphs.</td>
     </tr>
     <tr>
-      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_catalysis_irr_2_2.png"/> <br /> 
-          <a href="/sbgn/downloads/bricks/PD_catalysis_irr_2_2.sbgn">SBGN-ML</a> &ensp; 
+      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_catalysis_irr_2_2.png"/> <br />
+          <a href="/sbgn/downloads/bricks/PD_catalysis_irr_2_2.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/downloads/bricks/PD_catalysis_irr_2_2.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"><strong>Catalysis: multiple substrates and products.</strong> The enzyme catalyses an irreversible metabolic process which consumes two substrates S1 and S2 and produces two products P1 and P2.</td>
     </tr>
     <tr>
-    <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_inhibition.png"/> <br /> 
-          <a href="/sbgn/downloads/bricks/PD_inhibition.sbgn">SBGN-ML</a> &ensp; 
+    <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_inhibition.png"/> <br />
+          <a href="/sbgn/downloads/bricks/PD_inhibition.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/downloads/bricks/PD_inhibition.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"><strong>Inhibition: irreversible metabolic reaction.</strong> The inhibitor, a proteins shown with a <i>macromolecule</i> glyph, is connected to the <i>process</i> glyph by an <i>inhibition</i> arc.</td>
     </tr>
@@ -73,14 +73,14 @@ The example bricks are developed using the <a href="https://immersive-analytics.
 
 <table style="font-size:100%;">
     <tr>
-      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_phosphorylation_simple.png"/> <br /> 
-          <a href="/sbgn/downloads/bricks/PD_phosphorylation_simple.sbgn">SBGN-ML</a> &ensp; 
+      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_phosphorylation_simple.png"/> <br />
+          <a href="/sbgn/downloads/bricks/PD_phosphorylation_simple.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/downloads/bricks/PD_phosphorylation_simple.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"><strong>Protein phosphorylation.</strong> A kinase protein catalyzes an irreversible reaction which consumes unphosphorylated protein X and ATP and produces phosphorylated protein X and ADP. All proteins involved are represented by <i>macromolecules</i>.</td>
     </tr>
     <tr>
-      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_phosphorylation.png"/> <br /> 
-          <a href="/sbgn/downloads/bricks/PD_phosphorylation.sbgn">SBGN-ML</a> &ensp; 
+      <td style="width:200px; text-align:center; font-size:90%;"><img src="../sbgn/downloads/bricks/PD_phosphorylation.png"/> <br />
+          <a href="/sbgn/downloads/bricks/PD_phosphorylation.sbgn">SBGN-ML</a> &ensp;
           <a href="http://web.newteditor.org/?URL=http://sbgn.github.io/sbgn/downloads/bricks/PD_phosphorylation.sbgn" target="_blank">Newt</a></td>
       <td style="text-align:left;"><strong>Protein phosphorylation (with more details captured).</strong> A kinase protein catalyzes an irreversible reaction which consumes unphosphorylated protein X and ATP and produces phosphorylated protein X and ADP. All proteins involved are represented by <i>macromolecule</i> glyphs. <i>State variable</i> auxiliary glyphs are used to indicate the phosphorylation state: "P@Y701" means "phosphorylated at tyrosine 701" (one-letter amino acid code). Instead of empty state, "@Y701" without "P" can be used to indicate the position. ATP and ADP are represented as <i>simple chemicals</i>.</td>
     </tr>
@@ -94,7 +94,7 @@ The example bricks are developed using the <a href="https://immersive-analytics.
 
 ![iNOS](/sbgn/images/learning/iNOS_SBGN-ED.png)
 
-**Downloads:** &ensp; [PNG](/sbgn/images/learning/iNOS_SBGN-ED.png) &ensp; [SVG](/sbgn/images/learning/iNOS_SBGN-ED.svg) &ensp; [SBGN-ML](/sbgn/images/learning/iNOS_SBGN-ED.sbgn) &ensp; 
+**Downloads:** &ensp; [PNG](/sbgn/images/learning/iNOS_SBGN-ED.png) &ensp; [SVG](/sbgn/images/learning/iNOS_SBGN-ED.svg) &ensp; [SBGN-ML](/sbgn/images/learning/iNOS_SBGN-ED.sbgn) &ensp;
 
 <p>The diagram can be redrawn in any application that supports the required shapes, for example, in PowerPoint, InkScape or Adobe Illustrator. In GraphML format the diagram can be developed in <a href="https://www.yworks.com/products/yed" target="_blank">yEd Graph Editor</a> (desktop application) that since version 3.17.1 provides a palette section for SBGN.</p>
 
@@ -154,5 +154,3 @@ For more advanced questions please use <a href="/sbgn/faqs">FAQ</a>, in particul
 
 For questions and comments please contact the SBGN editors at  
 [sbgn-editors@googlegroups.com](mailto:sbgn-editors@googlegroups.com)
-
-

--- a/docs/software.md
+++ b/docs/software.md
@@ -16,13 +16,6 @@ This page summarizes what we know about software support for SBGN languages. Thi
 
 The following is a list of software packages known to provide support for SBGN. The links to the software packages were correct at the time of recording.
 
-<!--  [Please, delete this comment when/if approving a pull request]
-    Broken links with no idea how to fix them:
-      * Biographer. Snapshot of the editor, as of July 2017, can be seen at https://web.archive.org/web/20160725134705/http://biographer.biologie.hu-berlin.de/, should this link replace the current one?
-      * PathwayLab ('access denied' server response)
-      * SBMM assistant
--->
-
 | Software Package                                                                 | V / E | PD  | ER  | AF  | SBGN-ML |
 | -------------------------------------------------------------------------------- | :---: | :-: | :-: | :-: | :-----: |
 | [Arcadia](http://arcadiapathways.sourceforge.net/)                               | V     | +   | -   | -   | -       |

--- a/docs/software.md
+++ b/docs/software.md
@@ -16,6 +16,13 @@ This page summarizes what we know about software support for SBGN languages. Thi
 
 The following is a list of software packages known to provide support for SBGN. The links to the software packages were correct at the time of recording.
 
+<!--  [Please, delete this comment when/if approving a pull request]
+    Broken links with no idea how to fix them:
+      * Biographer. Snapshot of the editor, as of July 2017, can be seen at https://web.archive.org/web/20160725134705/http://biographer.biologie.hu-berlin.de/, should this link replace the current one?
+      * PathwayLab ('access denied' server response)
+      * SBMM assistant
+-->
+
 | Software Package                                                                 | V / E | PD  | ER  | AF  | SBGN-ML |
 | -------------------------------------------------------------------------------- | :---: | :-: | :-: | :-: | :-----: |
 | [Arcadia](http://arcadiapathways.sourceforge.net/)                               | V     | +   | -   | -   | -       |
@@ -28,21 +35,22 @@ The following is a list of software packages known to provide support for SBGN. 
 | [ChiBE](https://code.google.com/archive/p/chibe/)                                | E     | +   | -   | -   | -       |
 | [COPASI](http://copasi.org/)                                                     | V     | +   | -   | -   | -       |
 | [CySBGN](http://www.ebi.ac.uk/saezrodriguez/cno/cysbgn/)                         | V     | +   | +   | +   | +       |
-| [Dunnart](http://www.dunnart.org/)                                               | E     | +   | -   | -   | -       |
+| [Dunnart](http://users.monash.edu/~mwybrow/dunnart/)                             | E     | +   | -   | -   | -       |
 | [Edinburgh Pathway Editor](http://epe.sourceforge.net/)                          | E     | +   | +   | +   | -       |
 | [EscherConverter](https://escher.readthedocs.org/en/latest/escherconverter.html) | V     | +   | -   | -   | +       |
-| [geneXplain platform](http://genexplain.com/genexplain-platform-1)               | E     | +   | -   | -   | -       |
+| [geneXplain platform](http://genexplain.com/genexplain-platform/)                | E     | +   | -   | -   | -       |
 | [iPathways](http://www.ipathways.org/)                                           | V     | +   | -   | -   | -       |
 | [JWS Online](http://jjj.bio.vu.nl/)                                              | V     | +   | -   | -   | -       |
 | [KEGGtranslator](http://www.cogsys.cs.uni-tuebingen.de/software/KEGGtranslator/) | V     | +   | -   | -   | +       |
 | [Krayon for SBGN](https://github.com/wiese42/krayon4sbgn)                        | E     | +   | -   | -   | +       |
-| [Mayday MGV](http://it.inf.uni-tuebingen.de/?page_id=248)                        | V     | +   | -   | -   | -       |
+| [Mayday MGV](https://bit.ly/2BZR2g8)                                             | V     | +   | -   | -   | -       |
 | [Mimoza](http://mimoza.bordeaux.inria.fr/)                                       | V     | +   | -   | -   | -       |
 | [Netbuilder'](http://sourceforge.net/projects/apostrophe/)                       | E     | +   | -   | -   | -       |
 | [Newt Editor](http://newteditor.org/)                                            | E     | +   | -   | +   | +       |
 | [Omix](http://www.omix-visualization.com/)                                       | E     | -   | -   | -   | +       |
 | [PathVisio](http://www.pathvisio.org/plugin/sbgn-plugin/)                        | E     | +   | +   | +   | +       |
 | [PathwayLab](http://www.innetics.com/)                                           | E     | +   | -   | -   | -       |
+| [PathWiz](http://smpdb.ca/pathwhiz)                                              | E     | -   | -   | -   | +       |
 | [SBGN-ED](http://www.sbgn-ed.org/)                                               | E     | +   | +   | +   | +       |
 | [SBGNTikZ](https://github.com/Adrienrougny/sbgntikz)                             | E     | +   | +   | +   | -       |
 | [SBGNViz](http://www.cs.bilkent.edu.tr/~ivis/SBGNViz.js/)                        | V     | +   | -   | -   | +       |
@@ -93,7 +101,7 @@ One can compare the rendering of SBGN-ML by different software packages on the [
 ### BioPAX-SBGN Mapping
 
 [Biological Pathways Exchange (BioPAX)](https://biopax.github.io/) is a standard that aims to provide integration, exchange, visualization and analysis of biological pathway data. A substantial amount of BioPAX Level 3 concepts can be represented in SBGN PD via [BioPAX-SBGN Mapping](http://www.biopax.org/mediawiki/index.php/BioPAX-SBGN_Mapping). More information regarding BioPAX-SBGN Mapping software can be found [here](https://biopax.github.io/Paxtools/4.3.1/sbgn-converter/index.html).  
-   
+
 ### Biological Connection Markup Language (BCML)
 
 The [Biological Connection Markup Language (BCML)](http://bioinformatics.oxfordjournals.org/content/27/15/2127) is a format to describe, annotate and visualize pathways. BCML can be automatically converted into a SBGN-compliant graphical representation. More information regarding BCML software can be found [here](https://github.com/dc-atlas/bcml).


### PR DESCRIPTION
I have found some broken links on the page 'Software':

- **Biographer**  - Internal Error 500. Snapshot of the editor, as of July 2017, can be seen at [web.archive.org/web/20160725134705/http://biographer.biologie.hu-berlin.de](https://web.archive.org/web/20160725134705/http://biographer.biologie.hu-berlin.de/)
- **Dunnart** - Domain is expired.  I replaced it with http://users.monash.edu/~mwybrow/dunnart/
- **Mayday MGV** - Link was changed on the site, and as it became with a longer path, I shorten URL via bit.ly (to avoid breaking table in editing mode with a long string)
- **PathwayLab** - Forbidden 403 (Access denied)
- **SBMM assistant** - Connection Timeout

Also, I added PathWiz, that claims to support export to SBGN-ML.
